### PR TITLE
return ErrInvalid when token is too short

### DIFF
--- a/session.go
+++ b/session.go
@@ -79,6 +79,9 @@ func Get(r *http.Request, v interface{}, config *Config) error {
 	if err != nil {
 		return err
 	}
+	if len(t) < 32 {
+		return ErrInvalid
+	}
 	var nonce [24]byte
 	copy(nonce[:], t)
 	for _, key := range config.Keys {


### PR DESCRIPTION
See #1 for description of issue.
